### PR TITLE
Use server-side apply to avoid the issue of annotations being too long

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -53,7 +53,7 @@ func (o *publishOptions) publish(cmd *cobra.Command, args []string) error {
 	}
 
 	command := exec.Command("bash", "-c", fmt.Sprintf(`
-kubectl apply -f - <<EOF
+kubectl apply --server-side=true -f - <<EOF
 %s
 EOF`, ext.ToKubernetesResources()))
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
 	helm.sh/helm/v3 v3.10.1
+	k8s.io/api v0.25.2
 	k8s.io/apimachinery v0.25.2
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -46,7 +47,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.25.2 // indirect
 	k8s.io/apiextensions-apiserver v0.25.2 // indirect
 	k8s.io/client-go v0.25.2 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect


### PR DESCRIPTION
When creating a large chart, you may encounter the following issue:

```
The ConfigMap "xxx" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```

This is due to the automatic creation of the `last-applied-configuration` annotation exceeding the maximum length limit (262144 characters) when using the `kubectl apply` command. This PR uses server-side apply to avoid creating the `last-applied-configuration` annotation and solve this problem.

/cc @wansir 