### PR TITLE
Add package command to package an extension

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/otiai10/copy"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+
+	"github.com/kubesphere/ksbuilder/pkg/extension"
+)
+
+type packageOptions struct {
+}
+
+func defaultPackageOptions() *packageOptions {
+	return &packageOptions{}
+}
+
+func packageExtensionCmd() *cobra.Command {
+	o := defaultPackageOptions()
+
+	cmd := &cobra.Command{
+		Use:          "package",
+		Short:        "package an extension",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE:         o.packageCmd,
+	}
+	return cmd
+}
+
+func (o *packageOptions) packageCmd(cmd *cobra.Command, args []string) error {
+	pwd, _ := os.Getwd()
+	p := path.Join(pwd, args[0])
+	fmt.Printf("package extension %s\n", args[0])
+
+	tempDir, err := os.MkdirTemp("", "chart")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir) // nolint
+
+	if err = copy.Copy(p, tempDir); err != nil {
+		return err
+	}
+
+	metadata, err := extension.LoadMetadata(p)
+	if err != nil {
+		return err
+	}
+	chartYaml, err := metadata.ToChartYaml()
+	if err != nil {
+		return err
+	}
+	chartMetadata, err := yaml.Marshal(chartYaml)
+	if err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(tempDir+"/Chart.yaml", chartMetadata, 0644); err != nil {
+		return err
+	}
+
+	ch, err := loader.LoadDir(tempDir)
+	if err != nil {
+		return err
+	}
+	chartFilename, err := chartutil.Save(ch, pwd)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("package saved to %s\n", chartFilename)
+	return nil
+}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -47,6 +47,8 @@ func (o *publishOptions) publish(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(dir) // nolint
+
 	filePath := path.Join(dir, "extension.yaml")
 	if err = os.WriteFile(filePath, ext.ToKubernetesResources(), 0644); err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(versionCmd(version))
 	cmd.AddCommand(createExtensionCmd())
 	cmd.AddCommand(publishExtensionCmd())
+	cmd.AddCommand(packageExtensionCmd())
 
 	return cmd
 }

--- a/pkg/extension/publish.go
+++ b/pkg/extension/publish.go
@@ -39,6 +39,7 @@ func Load(path string) (*Extension, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer os.RemoveAll(tempDir) // nolint
 
 	err = copy.Copy(path, tempDir)
 	if err != nil {


### PR DESCRIPTION
Added a new command to package an extension, which will now output the zip file directly to the current directory

```
$ ksbuilder package test
package extension test
package saved to /xxx/test-0.1.0.tgz
```

ref https://github.com/kubesphere/issues/issues/1024
ref https://github.com/kubesphere/issues/issues/1097

/cc @wansir 