### PR TITLE
cmd/create: add vendor info to the metadata and change the author name parameter to required

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -13,8 +14,9 @@ import (
 )
 
 type promptContent struct {
+	text     string
+	optional bool
 	errorMsg string
-	label    string
 }
 
 func createExtensionCmd() *cobra.Command {
@@ -30,34 +32,41 @@ func createExtensionCmd() *cobra.Command {
 
 func run(cmd *cobra.Command, args []string) error {
 	extensionNamePrompt := promptContent{
+		text:     "Please input extension name",
 		errorMsg: "Extension name can't be empty",
-		label:    "Please input extension name: ",
 	}
-	name := promptGetRequiredInput(extensionNamePrompt)
+	name := promptGetInput(extensionNamePrompt)
 
 	categoryPromptContent := promptContent{
-		"Please provide a category.",
-		fmt.Sprintf("What category does %s belong to?", name),
+		text:     fmt.Sprintf("What category does %s belong to?", name),
+		errorMsg: "Please provide a category",
 	}
 	category := promptGetSelect(categoryPromptContent)
 
 	authorPrompt := promptContent{
+		text:     "Please input extension author",
 		errorMsg: "Extension author can't be empty",
-		label:    "Please input extension author",
 	}
 	author := promptGetInput(authorPrompt)
 
 	emailPrompt := promptContent{
-		errorMsg: "Email can't be empty",
-		label:    "Please input Email",
+		text:     "Please input Email",
+		optional: true,
 	}
 	email := promptGetInput(emailPrompt)
+
+	urlPrompt := promptContent{
+		text:     "Please input author's URL",
+		optional: true,
+	}
+	url := promptGetInput(urlPrompt)
 
 	extensionConfig := extension.Config{
 		Name:     name,
 		Category: category,
 		Author:   author,
 		Email:    email,
+		URL:      url,
 	}
 
 	pwd, _ := os.Getwd()
@@ -72,34 +81,28 @@ func run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+var (
+	bold  = promptui.Styler(promptui.FGBold)
+	faint = promptui.Styler(promptui.FGFaint)
+)
+
 func promptGetInput(pc promptContent) string {
 	prompt := promptui.Prompt{
-		Label: pc.label,
+		Label: pc.text,
 	}
 
-	result, _ := prompt.Run()
-	return result
-}
-
-func promptGetRequiredInput(pc promptContent) string {
-	validate := func(input string) error {
-		if len(input) <= 0 {
-			return errors.New(pc.errorMsg)
+	if pc.optional {
+		prompt.Templates = &promptui.PromptTemplates{
+			Valid:   fmt.Sprintf("%s {{ . | bold }} %s ", bold(promptui.IconGood), bold("(optional):")),
+			Success: fmt.Sprintf("{{ . | faint }} %s ", faint("(optional):")),
 		}
-		return nil
-	}
-
-	templates := &promptui.PromptTemplates{
-		Prompt:  "{{ . }} ",
-		Valid:   "{{ . | green }} ",
-		Invalid: "{{ . | red }} ",
-		Success: "{{ . | bold }} ",
-	}
-
-	prompt := promptui.Prompt{
-		Label:     pc.label,
-		Templates: templates,
-		Validate:  validate,
+	} else {
+		prompt.Validate = func(input string) error {
+			if len(strings.TrimSpace(input)) <= 0 {
+				return errors.New(pc.errorMsg)
+			}
+			return nil
+		}
 	}
 
 	result, err := prompt.Run()
@@ -107,8 +110,7 @@ func promptGetRequiredInput(pc promptContent) string {
 		fmt.Printf("Prompt failed %v\n", err)
 		os.Exit(1)
 	}
-
-	return result
+	return strings.TrimSpace(result)
 }
 
 func promptGetSelect(pc promptContent) string {
@@ -119,7 +121,7 @@ func promptGetSelect(pc promptContent) string {
 
 	for index < 0 {
 		prompt := promptui.Select{
-			Label: pc.label,
+			Label: pc.text,
 			Items: items,
 		}
 

--- a/pkg/extension/create.go
+++ b/pkg/extension/create.go
@@ -12,9 +12,10 @@ import (
 
 type Config struct {
 	Name     string
+	Category string
 	Author   string
 	Email    string
-	Category string
+	URL      string
 }
 
 //go:embed templates

--- a/pkg/extension/templates/extension.yaml
+++ b/pkg/extension/templates/extension.yaml
@@ -14,6 +14,10 @@ sources:
   - https://github.com/kubesphere
 kubeVersion: ">=1.19.0"
 ksVersion: ">=3.0.0"
+vendor:
+  name: "[[ .Author ]]"
+  email: "[[ .Email ]]"
+  url: "[[ .URL ]]"
 dependencies:
   - name: frontend
     condition: frontend.enabled

--- a/pkg/extension/type.go
+++ b/pkg/extension/type.go
@@ -49,6 +49,7 @@ type Metadata struct {
 	Version      string              `json:"version,omitempty"`
 	Keywords     []string            `json:"keywords,omitempty"`
 	Sources      []string            `json:"sources,omitempty"`
+	Vendor       *chart.Maintainer   `json:"vendor,omitempty"`
 	KubeVersion  string              `json:"kubeVersion,omitempty"`
 	KsVersion    string              `json:"ksVersion,omitempty"`
 	Home         string              `json:"home,omitempty"`
@@ -109,6 +110,7 @@ func (md *Metadata) ToChartYaml() (*chart.Metadata, error) {
 		Dependencies: md.Dependencies,
 		Description:  md.Description.Default(),
 		Icon:         md.Icon,
+		Maintainers:  []*chart.Maintainer{md.Vendor},
 	}
 
 	return &c, nil
@@ -135,6 +137,7 @@ spec:
   description: {{.Description | toJson}}
   displayName: {{.DisplayName | toJson}}
   icon: {{.Icon | quote}}
+  vendor: {{.Vendor | toJson}}
 status:
   recommendedVersion: {{.Version}}
 `)


### PR DESCRIPTION
```
$ ksbuilder create

Please input extension name: aaa
✔ Performance
Please input extension author: ia
Please input Email (optional):
Please input author's URL (optional):
Directory: /xxx/aaa

The extension charts has been created.
```

ref https://github.com/kubesphere/issues/issues/1024 https://github.com/kubesphere/issues/issues/1097

/cc @wansir 