### PR TITLE
Add a parser package to parse the metadata of an extension

### DIFF
--- a/pkg/parser/extension.go
+++ b/pkg/parser/extension.go
@@ -1,0 +1,87 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"helm.sh/helm/v3/pkg/chart"
+
+	"github.com/kubesphere/ksbuilder/pkg/extension"
+)
+
+type Extension struct {
+	ChartMetadata *chart.Metadata
+	DisplayName   string
+	README        []byte
+	Changelog     []byte
+	KSVersion     string
+	Vendor        *chart.Maintainer
+}
+
+type options struct {
+	language string
+}
+
+// WithLanguage specifies the language to use when parsing the extension.
+// The default value is `en`.
+func WithLanguage(language string) func(opts *options) {
+	return func(opts *options) {
+		opts.language = language
+	}
+}
+
+func ParseExtension(name string, zipFile []byte, opts ...func(*options)) (*Extension, error) {
+	o := &options{
+		language: "en",
+	}
+	for _, f := range opts {
+		f(o)
+	}
+
+	tempDir, err := os.MkdirTemp("", "chart")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tempDir) // nolint
+
+	if err = unzip(zipFile, tempDir); err != nil {
+		return nil, err
+	}
+
+	chartDir := path.Join(tempDir, name)
+	metadata, err := extension.LoadMetadata(chartDir)
+	if err != nil {
+		return nil, err
+	}
+	chartMetadata, err := metadata.ToChartYaml()
+	if err != nil {
+		return nil, err
+	}
+
+	readmeFileName := "README.md"
+	if o.language != extension.LanguageCodeEn {
+		readmeFileName = fmt.Sprintf("README_%s.md", o.language)
+	}
+	readmeData, err := readFile(chartDir, readmeFileName)
+	if err != nil {
+		return nil, err
+	}
+	changelogFileName := "CHANGELOG.md"
+	if o.language != extension.LanguageCodeEn {
+		changelogFileName = fmt.Sprintf("CHANGELOG_%s.md", o.language)
+	}
+	changelogData, err := readFile(tempDir, changelogFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Extension{
+		ChartMetadata: chartMetadata,
+		DisplayName:   string(metadata.DisplayName[extension.LanguageCode(o.language)]),
+		KSVersion:     metadata.KsVersion,
+		Vendor:        metadata.Vendor,
+		README:        readmeData,
+		Changelog:     changelogData,
+	}, nil
+}

--- a/pkg/parser/utils.go
+++ b/pkg/parser/utils.go
@@ -1,0 +1,62 @@
+package parser
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+func unzip(zipFile []byte, dest string) error {
+	gr, err := gzip.NewReader(bytes.NewReader(zipFile))
+	if err != nil {
+		return err
+	}
+	defer gr.Close() // nolint
+
+	tr := tar.NewReader(gr)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		p := path.Join(dest, h.Name)
+		if h.FileInfo().IsDir() {
+			if err = os.MkdirAll(p, os.ModePerm); err != nil {
+				return err
+			}
+			continue
+		}
+		if err = os.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
+			return err
+		}
+		fw, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, h.FileInfo().Mode())
+		if err != nil {
+			return err
+		}
+		defer fw.Close() // nolint
+
+		if _, err = io.Copy(fw, tr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readFile(dir, name string) ([]byte, error) {
+	data, err := os.ReadFile(path.Join(dir, name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return data, nil
+}


### PR DESCRIPTION
Usage example:

```go
func main() {
	file, _ := os.ReadFile("test-0.1.0.tgz")
	extension, err := parser.ParseExtension("test", file, parser.WithLanguage("zh"))
	if err != nil {
		panic(err)
	}
	data, _ := json.Marshal(extension)
	fmt.Println(string(data))
}
```

ref https://github.com/kubesphere/issues/issues/1097 https://github.com/kubesphere/issues/issues/1024