### PR TITLE
Update the chart version to v2 to fix the dependency dropping issue

### DIFF
--- a/pkg/extension/publish.go
+++ b/pkg/extension/publish.go
@@ -62,7 +62,7 @@ func LoadApplicationClass(name, p, tempDir string) error {
 	}
 
 	c := &chart.Metadata{
-		APIVersion: "v1",
+		APIVersion: chart.APIVersionV2,
 		Name:       appClass.Name,
 		Version:    appClass.PackageVersion,
 		AppVersion: appClass.AppVersion,

--- a/pkg/extension/templates/extension.yaml
+++ b/pkg/extension/templates/extension.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: kubesphere.io/v1alpha1
 name: [[ .Name ]]
 version: 0.1.0
 displayName:

--- a/pkg/extension/type.go
+++ b/pkg/extension/type.go
@@ -114,8 +114,8 @@ func (md *Metadata) LoadIcon(p string) error {
 
 func (md *Metadata) ToChartYaml() (*chart.Metadata, error) {
 	var c = chart.Metadata{
+		APIVersion:   chart.APIVersionV2,
 		Name:         md.Name,
-		APIVersion:   md.APIVersion,
 		Version:      md.Version,
 		Keywords:     md.Keywords,
 		Sources:      md.Sources,


### PR DESCRIPTION
ref https://github.com/helm/helm/pull/7009

```
[ERROR] Chart.yaml: dependencies are not valid in the Chart file with apiVersion 'v1'. They are valid in apiVersion 'v2'   
```

ref https://github.com/kubesphere/issues/issues/1361

/cc @wansir 