### PR TITLE
Force update fields to handle conflicts

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -54,7 +54,7 @@ func (o *publishOptions) publish(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	kubectlArgs := []string{"apply", "--server-side=true", "-f", filePath}
+	kubectlArgs := []string{"apply", "--server-side=true", "--force-conflicts", "-f", filePath}
 	if o.kubeconfig != "" {
 		kubectlArgs = append(kubectlArgs, "--kubeconfig", o.kubeconfig)
 	}


### PR DESCRIPTION
If some of the fields of an already published extension have been changed by someone else, then using ksbuilder to publish the extension will cause a conflict, in which case we need to force the existing values to be overwritten, based on the contents of the extension package, see https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts for more info.

ref https://github.com/kubesphere/issues/issues/1595

/cc @wansir 