### PR TITLE
Add the validate sub-command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(publishExtensionCmd())
 	cmd.AddCommand(packageExtensionCmd())
 	cmd.AddCommand(unpublishExtensionCmd())
+	cmd.AddCommand(validateExtensionCmd())
 
 	return cmd
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubesphere/ksbuilder/pkg/extension"
+)
+
+type validateOptions struct{}
+
+func validateExtensionCmd() *cobra.Command {
+	o := &validateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "",
+		Args:  cobra.ExactArgs(1),
+		RunE:  o.validate,
+	}
+	return cmd
+}
+
+func (o *validateOptions) validate(_ *cobra.Command, args []string) error {
+	pwd, _ := os.Getwd()
+	p := path.Join(pwd, args[0])
+	fmt.Printf("validating extension %s\n", args[0])
+
+	if _, err := extension.Load(p); err != nil {
+		return err
+	}
+	fmt.Println("\nno issues found")
+	return nil
+}


### PR DESCRIPTION
```
$ ksbuilder validate test-1.0.0.tgz
validating extension test-1.0.0.tgz

no issues found
```

```
$ ksbuilder validate tower
validating extension tower

error executing command: invalid language code zh1, see https://www.loc.gov/standards/iso639-2/php/code_list.php for more details
exit status 1
```

close #71 