### PR TITLE
fix: use --set-json instance of --set in global.nodeSelector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean: ## clean up environment
 
 PHONY: cover
 cover: ## display test coverage
-	go test -v -race ./... -coverprofile=coverage.out
+	go test -v ./... -coverprofile=coverage.out
 	go tool cover -func=coverage.out
 
 PHONY: fmt

--- a/pkg/helm/lint.go
+++ b/pkg/helm/lint.go
@@ -106,12 +106,12 @@ func lintAll(basedir string, values map[string]interface{}, namespace string, st
 	// For ks-extension it's not exist.
 	//rules.Chartfile(&linter)
 	rules.ValuesWithOverrides(&linter, values)
-	lintTemplates(&linter, values, namespace, strict, metadata)
-	lintDependencies(&linter, metadata)
+	lintTemplates(&linter, values, namespace, strict, *metadata)
+	lintDependencies(&linter, *metadata)
 	return linter
 }
 
-func lintTemplates(linter *support.Linter, values map[string]interface{}, namespace string, strict bool, metadata *chart.Metadata) {
+func lintTemplates(linter *support.Linter, values map[string]interface{}, namespace string, strict bool, metadata chart.Metadata) {
 	fpath := "templates/"
 	templatesPath := filepath.Join(linter.ChartDir, fpath)
 
@@ -124,7 +124,7 @@ func lintTemplates(linter *support.Linter, values map[string]interface{}, namesp
 
 	// Load chart and parse templates
 	//chart, err := LoadHelmCharts(linter.ChartDir)
-	chart, err := Load(linter.ChartDir, metadata)
+	chart, err := Load(linter.ChartDir, &metadata)
 	if err != nil {
 		return
 	}
@@ -233,8 +233,8 @@ func lintTemplates(linter *support.Linter, values map[string]interface{}, namesp
 // Dependencies runs lints against a chart's dependencies
 //
 // See https://github.com/helm/helm/issues/7910
-func lintDependencies(linter *support.Linter, metadata *chart.Metadata) {
-	c, err := Load(linter.ChartDir, metadata)
+func lintDependencies(linter *support.Linter, metadata chart.Metadata) {
+	c, err := Load(linter.ChartDir, &metadata)
 	if !linter.RunLinterRule(support.ErrorSev, "", validateChartFormat(err)) {
 		return
 	}


### PR DESCRIPTION
fix:[ chart is changed unexpect when use lint command](https://github.com/kubesphere/ksbuilder/issues/80)
1: use` --set-json` instance of `--set` in global.nodeSelector
fix: **waring: cannot overwrite table with non table for whizard-monitoring-global.nodeSelector (map[])**
2: chart is changed unexpect when use lint command
fix: **chart metadata is missing these dependencies:**