### PR TITLE
parser: fix the problem that tar content is not completely read

### DIFF
--- a/pkg/parser/validate.go
+++ b/pkg/parser/validate.go
@@ -39,7 +39,7 @@ func ValidateExtension(name string, zipFile []byte) error {
 			continue
 		}
 		buffer := make([]byte, h.Size)
-		if _, err = tr.Read(buffer); err != nil && err != io.EOF {
+		if _, err = io.ReadFull(tr, buffer); err != nil && err != io.EOF {
 			return fmt.Errorf("read tar file failed: %s", err.Error())
 		}
 		metadata := new(extension.Metadata)


### PR DESCRIPTION
fix #84

The comment in https://github.com/kubesphere/ksbuilder/issues/84#issue-2164752099 is right, the tar content may not be fully read in the `validate` cmd.

ref:
https://github.com/kubesphere/ksbuilder/blob/89a3e5a4fe0b8825242ba954e0f5efa472466538/pkg/utils/utils.go#L32-L35

/cc @stoneshi-yunify 