### PR TITLE
fix: only check yaml files in templates

### DIFF
--- a/pkg/extension/lint.go
+++ b/pkg/extension/lint.go
@@ -190,6 +190,10 @@ func WithBuiltins(paths []string) error {
 	}
 
 	for name, content := range files {
+		// only deal yaml files
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
 		for _, vt := range valueValidators {
 			if err := vt.Validate(name, content); err != nil {
 				return err


### PR DESCRIPTION
fix: If there are files in the "templates" directory that are not in YAML format, an error will occur when using the "ksbuilder lint" command.
![WeChatWorkScreenshot_9c5cb6ad-8473-4571-a8dd-820587e33130](https://github.com/kubesphere/ksbuilder/assets/54946465/7c75d560-8bb0-4092-9cb6-b4723e7f182b)

```release-note
only check yaml files in templates
```