### PR TITLE
Integrate with KubeSphere Cloud

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+
+	"github.com/kubesphere/ksbuilder/pkg/cloud"
+	"github.com/kubesphere/ksbuilder/pkg/config"
+)
+
+type loginOptions struct {
+	token  string
+	server string
+}
+
+func loginCmd() *cobra.Command {
+	o := loginOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Login to KubeSphere Cloud",
+		Args:  cobra.NoArgs,
+		RunE:  o.login,
+	}
+	cmd.Flags().StringVarP(&o.token, "token", "t", "", "API access token")
+	cmd.Flags().StringVar(&o.server, "server", "https://apis.kubesphere.cloud", "API server address")
+	return cmd
+}
+
+func (o *loginOptions) login(_ *cobra.Command, _ []string) error {
+	if o.token == "" {
+		prompt := promptui.Prompt{
+			Label: "Enter API token",
+			Mask:  '*',
+			Validate: func(input string) error {
+				if len(strings.TrimSpace(input)) <= 0 {
+					return errors.New("token can't be empty")
+				}
+				return nil
+			},
+		}
+		result, err := prompt.Run()
+		if err != nil {
+			return err
+		}
+		o.token = result
+	}
+
+	if _, err := cloud.NewClient(cloud.WithToken(o.token), cloud.WithServer(o.server)); err != nil {
+		return fmt.Errorf("login failed: %v", err)
+	}
+	if err := config.Write([]byte(o.token), o.server); err != nil {
+		return err
+	}
+	fmt.Println("Login Succeeded")
+	return nil
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubesphere/ksbuilder/pkg/config"
+)
+
+type logoutOptions struct{}
+
+func logoutCmd() *cobra.Command {
+	o := logoutOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Log out from KubeSphere Cloud",
+		Args:  cobra.NoArgs,
+		RunE:  o.logout,
+	}
+	return cmd
+}
+
+func (o *logoutOptions) logout(_ *cobra.Command, _ []string) error {
+	if err := config.Remove(); err != nil {
+		return err
+	}
+	fmt.Println("Logout Succeeded")
+	return nil
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubesphere/ksbuilder/pkg/cloud"
+	"github.com/kubesphere/ksbuilder/pkg/extension"
+)
+
+type pushOptions struct{}
+
+func pushCmd() *cobra.Command {
+	o := pushOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: "Push and submit extensions to KubeSphere Cloud for review",
+		Long: `NOTE: We will upload static files such as icons and screenshots in the extension to the KubeSphere Cloud separately
+and delete the static file directory in the original package to reduce the size of the entire chart`,
+		Args: cobra.ExactArgs(1),
+		RunE: o.push,
+	}
+	return cmd
+}
+
+func (o *pushOptions) push(_ *cobra.Command, args []string) error {
+	fmt.Printf("push extension %s\n", args[0])
+
+	client, err := cloud.NewClient()
+	if err != nil {
+		return fmt.Errorf("login failed: %v", err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "chart")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+	if err = extension.WriteFilesToTempDir(args[0], tempDir); err != nil {
+		return err
+	}
+
+	metadata, err := extension.LoadMetadata(tempDir)
+	if err != nil {
+		return err
+	}
+	// upload images to cloud
+	if needUpload(metadata.Icon) {
+		resp, err := client.UploadFiles(metadata.Name, metadata.Version, tempDir, metadata.Icon)
+		if err != nil {
+			return err
+		}
+		metadata.Icon = resp.Files[0].URL
+	}
+	screenshots := make([]string, 0)
+	localScreenshots := make([]string, 0)
+	for _, p := range metadata.Screenshots {
+		if needUpload(p) {
+			localScreenshots = append(localScreenshots, p)
+		} else {
+			screenshots = append(screenshots, p)
+		}
+	}
+	if len(localScreenshots) > 0 {
+		resp, err := client.UploadFiles(metadata.Name, metadata.Version, tempDir, localScreenshots...)
+		if err != nil {
+			return err
+		}
+		for _, f := range resp.Files {
+			screenshots = append(screenshots, f.URL)
+		}
+		metadata.Screenshots = screenshots
+	}
+	// delete static directory to reduce chart package size
+	if metadata.StaticFileDirectory != "" {
+		if err = os.RemoveAll(filepath.Join(tempDir, metadata.StaticFileDirectory)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	data, err := yaml.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(tempDir+"/"+extension.MetadataFilename, data, 0644); err != nil {
+		return err
+	}
+
+	chartYaml, err := metadata.ToChartYaml()
+	if err != nil {
+		return err
+	}
+	chartMetadata, err := yaml.Marshal(chartYaml)
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(tempDir+"/Chart.yaml", chartMetadata, 0644); err != nil {
+		return err
+	}
+
+	ch, err := loader.LoadDir(tempDir)
+	if err != nil {
+		return err
+	}
+	chartFilename, err := chartutil.Save(ch, tempDir)
+	if err != nil {
+		return err
+	}
+
+	uploadExtensionResp, err := client.UploadExtension(metadata.Name, chartFilename)
+	if err != nil {
+		return err
+	}
+	if err = client.SubmitExtension(uploadExtensionResp.Snapshot.SnapshotID); err != nil {
+		return err
+	}
+	fmt.Println("Pushed to KubeSphere Cloud")
+	return nil
+}
+
+func needUpload(path string) bool {
+	if strings.HasPrefix(path, "http://") ||
+		strings.HasPrefix(path, "https://") ||
+		strings.HasPrefix(path, "data:image") {
+		return false
+	}
+	return true
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,9 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(validateExtensionCmd())
 	cmd.AddCommand(lintExtensionCmd())
 	cmd.AddCommand(templateExtensionCmd())
+	cmd.AddCommand(loginCmd())
+	cmd.AddCommand(logoutCmd())
+	cmd.AddCommand(pushCmd())
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,13 @@ module github.com/kubesphere/ksbuilder
 go 1.21
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/iawia002/lia v0.5.1
 	github.com/manifoldco/promptui v0.9.0
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
@@ -28,10 +31,8 @@ require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/hcsshim v0.11.0 // indirect
-	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -449,6 +449,7 @@ github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKju
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1,0 +1,208 @@
+package cloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kubesphere/ksbuilder/pkg/config"
+)
+
+type Options struct {
+	server string
+	token  string
+}
+
+func WithServer(server string) func(opts *Options) {
+	return func(opts *Options) {
+		opts.server = server
+	}
+}
+
+func WithToken(token string) func(opts *Options) {
+	return func(opts *Options) {
+		opts.token = token
+	}
+}
+
+type Client struct {
+	client *http.Client
+	server string
+	token  string
+	userID string
+}
+
+func NewClient(options ...func(*Options)) (*Client, error) {
+	c, err := config.Read()
+	if err != nil {
+		return nil, err
+	}
+	opts := &Options{
+		token:  string(c.Token),
+		server: c.Server,
+	}
+	for _, f := range options {
+		f(opts)
+	}
+	if opts.server == "" {
+		opts.server = "https://apis.kubesphere.cloud"
+	}
+
+	client := &Client{
+		client: http.DefaultClient,
+		server: opts.server,
+		token:  opts.token,
+	}
+
+	data := &userInfo{}
+	if err = client.sendRequest(http.MethodGet, "/apis/user/v1/user", nil, nil, data); err != nil {
+		return nil, err
+	}
+	client.userID = data.UserID
+	return client, nil
+}
+
+func (c *Client) sendRequest(method, path string, body io.Reader, headers map[string]string, respData interface{}) error {
+	req, err := http.NewRequest(method, c.server+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		data := errorResponse{}
+		if err = json.Unmarshal(responseBody, &data); err != nil {
+			return err
+		}
+		return fmt.Errorf("%s, %s", resp.Status, data.Message)
+	}
+
+	if respData == nil {
+		return nil
+	}
+	return json.Unmarshal(responseBody, respData)
+}
+
+func (c *Client) UploadFiles(extensionName, extensionVersion, sourceDir string, paths ...string) (*UploadFilesResponse, error) {
+	if len(paths) == 0 {
+		return &UploadFilesResponse{}, nil
+	}
+
+	fileUsage := &fileUsageResponse{}
+	if err := c.sendRequest(
+		http.MethodGet, fmt.Sprintf("/apis/extension/v1/users/%s/files/usage", c.userID), nil, nil, fileUsage,
+	); err != nil {
+		return nil, err
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	for i, path := range paths {
+		if err := func() error {
+			f, err := os.Open(filepath.Join(sourceDir, path))
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			fileName := filepath.Base(f.Name())
+			part, err := writer.CreateFormFile(fmt.Sprintf("file%d", i+1), fileName)
+			if err != nil {
+				return err
+			}
+			if _, err = io.Copy(part, f); err != nil {
+				return err
+			}
+			if err = writer.WriteField(
+				fmt.Sprintf("file%d_path", i+1),
+				filepath.Join(fileUsage.Dir, extensionName, extensionVersion, fileName),
+			); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	data := &UploadFilesResponse{}
+	if err := c.sendRequest(
+		http.MethodPost,
+		fmt.Sprintf("/apis/extension/v1/users/%s/files", c.userID),
+		body,
+		map[string]string{"Content-Type": writer.FormDataContentType()},
+		data,
+	); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (c *Client) UploadExtension(extensionName, path string) (*UploadExtensionResponse, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fileName := filepath.Base(f.Name())
+	part, err := writer.CreateFormFile("extension_package", fileName)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = io.Copy(part, f); err != nil {
+		return nil, err
+	}
+	if err = writer.Close(); err != nil {
+		return nil, err
+	}
+
+	data := &UploadExtensionResponse{}
+	if err = c.sendRequest(
+		http.MethodPost,
+		fmt.Sprintf("/apis/extension/v1/users/%s/extensions/%s/package?force=true&create_extension=true", c.userID, extensionName),
+		body,
+		map[string]string{"Content-Type": writer.FormDataContentType()},
+		data,
+	); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (c *Client) SubmitExtension(snapshotID string) error {
+	body := &bytes.Buffer{}
+	body.WriteString(fmt.Sprintf(`{"message": "%s submit for review"}`, time.Now().Format(time.RFC3339)))
+
+	return c.sendRequest(
+		http.MethodPost,
+		fmt.Sprintf("/apis/extension/v1/users/%s/snapshots/%s/action:submit", c.userID, snapshotID),
+		body,
+		map[string]string{"Content-Type": "application/json"},
+		nil,
+	)
+}

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -1,0 +1,25 @@
+package cloud
+
+type userInfo struct {
+	UserID string `json:"user_id"`
+}
+
+type errorResponse struct {
+	Message string `json:"message"`
+}
+
+type fileUsageResponse struct {
+	Dir string `json:"dir"`
+}
+
+type UploadFilesResponse struct {
+	Files []struct {
+		URL string `json:"url"`
+	} `json:"files"`
+}
+
+type UploadExtensionResponse struct {
+	Snapshot struct {
+		SnapshotID string `json:"snapshot_id"`
+	} `json:"snapshot"`
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+const (
+	configDir      = ".ksbuilder"
+	configFilename = "config.json"
+)
+
+type Config struct {
+	Token  []byte `json:"token"`
+	Server string `json:"server"`
+}
+
+func Write(token []byte, server string) error {
+	home, err := homedir.Dir()
+	if err != nil {
+		return err
+	}
+	root := filepath.Join(home, configDir)
+	if _, err = os.Stat(root); os.IsNotExist(err) {
+		if err = os.Mkdir(root, 0755); err != nil {
+			return err
+		}
+	}
+	config := &Config{
+		Token:  token,
+		Server: server,
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(root, configFilename), data, 0644)
+}
+
+func Read() (*Config, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(filepath.Join(home, configDir, configFilename))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	config := &Config{}
+	if err = json.Unmarshal(data, config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func Remove() error {
+	home, err := homedir.Dir()
+	if err != nil {
+		return err
+	}
+	return os.Remove(filepath.Join(home, configDir, configFilename))
+}

--- a/pkg/extension/publish.go
+++ b/pkg/extension/publish.go
@@ -36,9 +36,10 @@ func LoadMetadata(path string) (*Metadata, error) {
 	if err = metadata.Validate(); err != nil {
 		return nil, err
 	}
-	if err = metadata.Init(path); err != nil {
+	if err = metadata.Init(); err != nil {
 		return nil, err
 	}
+	metadata.path = path
 	return metadata, nil
 }
 
@@ -132,7 +133,7 @@ func removeOutDir(path string) string {
 	return filepath.Join(elements[1:]...)
 }
 
-func writeFilesToTempDir(path, tempDir string) error {
+func WriteFilesToTempDir(path, tempDir string) error {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -170,7 +171,7 @@ func Load(path string) (*Extension, error) {
 	}
 	defer os.RemoveAll(tempDir) // nolint
 
-	if err = writeFilesToTempDir(path, tempDir); err != nil {
+	if err = WriteFilesToTempDir(path, tempDir); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
ref https://github.com/kubesphere/issues/issues/1684

增加两个子命令用于上传扩展组件到 ks cloud：

```
login       Login to KubeSphere Cloud
logout      Log out from KubeSphere Cloud
push        Push and submit extensions to KubeSphere Cloud for review
```

登录需要提前创建 API access token https://github.com/kubesphere/project/issues/1931

```
$ ksbuilder login -t xxx

Login Succeeded
```

```
$ ksbuilder login
✔ Enter API token: ***

Login Succeeded
```

`push` 子命令类似于 `publish`，可以是一个目录，也可以是打包好的 `.tgz` 文件：

```
$ ksbuilder push tower

$ ksbuilder push tower-1.0.0.tgz
```

`login` 和 `push` 调用 API 遇到任何报错都会展示 cloud 返回的错误，比如：

```
$ ksbuilder login -t aa

error executing command: login failed: 403 Forbidden, permission denied
``` 

/cc @wansir @stoneshi-yunify 