### PR TITLE
Unify the parsing process of extension metadata

### DIFF
--- a/pkg/parser/extension.go
+++ b/pkg/parser/extension.go
@@ -1,17 +1,12 @@
 package parser
 
 import (
-	"encoding/base64"
 	"fmt"
-	"mime"
-	"net/http"
 	"path"
-	"strings"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1alpha1 "kubesphere.io/api/core/v1alpha1"
-	"sigs.k8s.io/yaml"
 
 	"github.com/kubesphere/ksbuilder/pkg/extension"
 	"github.com/kubesphere/ksbuilder/pkg/utils"
@@ -37,7 +32,7 @@ func ParseExtension(name string, zipFile []byte) (*Extension, error) {
 		return nil, err
 	}
 
-	metadata, err := parseMetadata(name, data)
+	metadata, err := extension.ParseMetadata(data[path.Join(name, extension.MetadataFilename)])
 	if err != nil {
 		return nil, err
 	}
@@ -80,32 +75,4 @@ func ParseExtension(name string, zipFile []byte) (*Extension, error) {
 		SupportedLanguages: supportedLanguages,
 		Docs:               metadata.Docs,
 	}, nil
-}
-
-func parseMetadata(name string, data map[string][]byte) (*extension.Metadata, error) {
-	metadata := new(extension.Metadata)
-	if err := yaml.Unmarshal(data[path.Join(name, extension.MetadataFilename)], metadata); err != nil {
-		return nil, err
-	}
-	if err := metadata.Validate(); err != nil {
-		return nil, fmt.Errorf("validate the extension metadata failed: %s", err.Error())
-	}
-	if strings.HasPrefix(metadata.Icon, "http://") ||
-		strings.HasPrefix(metadata.Icon, "https://") ||
-		strings.HasPrefix(metadata.Icon, "data:image") {
-		return metadata, nil
-	}
-
-	iconData := data[path.Join(name, metadata.Icon)]
-
-	var base64Encoding string
-	mimeType := mime.TypeByExtension(path.Ext(metadata.Icon))
-	if mimeType == "" {
-		mimeType = http.DetectContentType(iconData)
-	}
-
-	base64Encoding += "data:" + mimeType + ";base64,"
-	base64Encoding += base64.StdEncoding.EncodeToString(iconData)
-	metadata.Icon = base64Encoding
-	return metadata, nil
 }

--- a/pkg/parser/validate.go
+++ b/pkg/parser/validate.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"path"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/kubesphere/ksbuilder/pkg/extension"
 )
 
@@ -42,9 +40,9 @@ func ValidateExtension(name string, zipFile []byte) error {
 		if _, err = io.ReadFull(tr, buffer); err != nil && err != io.EOF {
 			return fmt.Errorf("read tar file failed: %s", err.Error())
 		}
-		metadata := new(extension.Metadata)
-		if err = yaml.Unmarshal(buffer, metadata); err != nil {
-			return fmt.Errorf("unmarshal the extension metadata failed: %s", err.Error())
+		metadata, err := extension.ParseMetadata(buffer)
+		if err != nil {
+			return fmt.Errorf("parse the extension metadata failed: %s", err.Error())
 		}
 		if err = metadata.Validate(); err != nil {
 			return fmt.Errorf("validate the extension metadata failed: %s", err.Error())


### PR DESCRIPTION
fix https://github.com/kubesphere/ksbuilder/issues/100

extension metadata:
<img width="786" alt="Screenshot 2024-06-27 at 15 06 15" src="https://github.com/kubesphere/ksbuilder/assets/9134003/3cd36536-2bce-4761-b4fd-b933f01dcc3e">

chart metadata:
<img width="801" alt="Screenshot 2024-06-27 at 15 06 26" src="https://github.com/kubesphere/ksbuilder/assets/9134003/4bf93a6b-0ad3-4a4c-98c0-f065d2d2accb">

cc @stoneshi-yunify 