### PR TITLE
fix: error split file when "---" in value.

### DIFF
--- a/pkg/extension/lint.go
+++ b/pkg/extension/lint.go
@@ -242,7 +242,7 @@ func lintGlobalNodeSelector(o options.LintOptions, charts chart.Chart, extension
 			continue
 		}
 
-		yamlArr := strings.Split(content, "---")
+		yamlArr := strings.Split(content, "\n---")
 		for _, y := range yamlArr {
 			var yamlMap map[string]any
 			if err := yaml.Unmarshal([]byte(y), &yamlMap); err != nil {
@@ -350,13 +350,13 @@ func lintGlobalImageRegistry(o options.LintOptions, charts chart.Chart, extensio
 		}
 
 		// Split YAML into individual documents
-		yamlArr := strings.Split(content, "---")
+		yamlArr := strings.Split(content, "\n---")
 		for _, y := range yamlArr {
 			yamlMap := make(map[string]any)
 
 			// Unmarshal YAML content
 			if err := yaml.Unmarshal([]byte(y), &yamlMap); err != nil {
-				return err
+				return fmt.Errorf("failed to unmarshal file %s. error: %w", filename, err)
 			}
 
 			// Check resources based on their kind


### PR DESCRIPTION
### What this PR does / why we need it:

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
error split file when "---" in value.
```
if "---" contains in yaml's value. it's should not split. sample:
```yaml
a: |
  ---
  bcd
````
we should only split file as a simple resource when contains "\n---"