### PR TITLE
refactor: standardize resource naming and improve lint messages

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -19,9 +19,7 @@ import (
 type publishOptions struct {
 	kubeconfig string
 
-	// only generate kubernetes resource. and do not apply to k8s cluster
-	localTemplate bool
-	// the template output path.default current dir. only used when localTemplate is true
+	dryRun bool
 	output string
 }
 
@@ -45,7 +43,7 @@ func publishExtensionCmd() *cobra.Command {
 		RunE:  o.publish,
 	}
 	cmd.Flags().StringVar(&o.kubeconfig, "kubeconfig", "", "kubeconfig file path of the target cluster")
-	cmd.Flags().BoolVar(&o.localTemplate, "to-local-template", o.localTemplate, "publish to local template instead of k8s cluster")
+	cmd.Flags().BoolVar(&o.dryRun, "dryRun", o.dryRun, "generate the local template without applying to the cluster")
 	cmd.Flags().StringVar(&o.output, "output", o.output, "the output path of the local template")
 	return cmd
 }
@@ -62,14 +60,18 @@ func (o *publishOptions) publish(_ *cobra.Command, args []string) error {
 		}
 	} else {
 		pwd, _ := os.Getwd()
-		ext, err = extension.Load(path.Join(pwd, args[0]))
+		location := args[0]
+		if !path.IsAbs(location) {
+			location = path.Join(pwd, location)
+		}
+		ext, err = extension.Load(location)
 		if err != nil {
 			return err
 		}
 	}
 
 	// generate resources
-	if o.localTemplate {
+	if o.dryRun {
 		fmt.Printf("generate resources to %s\n", o.output)
 		if _, err := os.Stat(o.output); os.IsNotExist(err) {
 			if err := os.MkdirAll(o.output, 0755); err != nil {

--- a/pkg/api/extension.go
+++ b/pkg/api/extension.go
@@ -24,6 +24,7 @@ type Extension struct {
 }
 
 func (ext *Extension) ToKubernetesResources() []runtimeclient.Object {
+	now := metav1.Now()
 	var resources = []runtimeclient.Object{
 		&corev1alpha1.Extension{
 			TypeMeta: metav1.TypeMeta{
@@ -43,11 +44,8 @@ func (ext *Extension) ToKubernetesResources() []runtimeclient.Object {
 					DisplayName: ext.Metadata.DisplayName,
 					Icon:        ext.Metadata.Icon,
 					Provider:    ext.Metadata.Provider,
-					Created:     metav1.Now(),
+					Created:     now,
 				},
-			},
-			Status: corev1alpha1.ExtensionStatus{
-				RecommendedVersion: ext.Metadata.Version,
 			},
 		}}
 	extensionVersion := &corev1alpha1.ExtensionVersion{
@@ -70,19 +68,8 @@ func (ext *Extension) ToKubernetesResources() []runtimeclient.Object {
 				DisplayName: ext.Metadata.DisplayName,
 				Icon:        ext.Metadata.Icon,
 				Provider:    ext.Metadata.Provider,
-				Created:     metav1.Now(),
+				Created:     now,
 			},
-			Docs:                 ext.Metadata.Docs,
-			Namespace:            ext.Metadata.Namespace,
-			Home:                 ext.Metadata.Home,
-			Keywords:             ext.Metadata.Keywords,
-			KSVersion:            ext.Metadata.KSVersion,
-			KubeVersion:          ext.Metadata.KubeVersion,
-			Sources:              ext.Metadata.Sources,
-			Version:              ext.Metadata.Version,
-			Category:             ext.Metadata.Category,
-			Screenshots:          ext.Metadata.Screenshots,
-			ExternalDependencies: ext.Metadata.ExternalDependencies,
 		},
 	}
 	if ext.ChartURL != "" {

--- a/pkg/extension/lint.go
+++ b/pkg/extension/lint.go
@@ -180,7 +180,7 @@ func WithBuiltins(o *options.LintOptions, paths []string) error {
 func lintExtensionsName(extension string) error {
 	fmt.Print("\nInfo: lint name\n")
 	if errs := validation.IsDNS1123Subdomain(extension); len(errs) != 0 {
-		fmt.Printf("ERROR: extension name \"%s\" is invalid:\n  error: %s\n", extension, strings.Join(errs, "\n  error: "))
+		fmt.Printf("ERROR: invalid extension name \"%s\":\n  error: %s\n", extension, strings.Join(errs, "\n  error: "))
 	}
 	return nil
 }
@@ -188,7 +188,7 @@ func lintExtensionsName(extension string) error {
 func lintExtensionsImages(o options.LintOptions, charts chart.Chart, extension string, images []string) error {
 	fmt.Print("\nInfo: lint images\n")
 	if len(images) == 0 {
-		fmt.Printf("WARNING: extension %s has no images\n", extension)
+		fmt.Printf("WARNING: extension %s has no image definitions\n", extension)
 		return nil
 	}
 
@@ -209,7 +209,7 @@ func lintExtensionsImages(o options.LintOptions, charts chart.Chart, extension s
 				goto found
 			}
 		}
-		fmt.Printf("WARNING: image %s has not found\n", image)
+		fmt.Printf("WARNING: image %s was not found\n", image)
 	found:
 	}
 	return nil
@@ -407,10 +407,9 @@ func getTemplateFile(o *options.LintOptions, chartRequested *chart.Chart) (map[s
 	top := map[string]interface{}{
 		"Chart":        chartRequested.Metadata,
 		"Capabilities": chartutil.DefaultCapabilities.Copy(),
-		// set Release undefined
 		"Release": map[string]interface{}{
-			"Name":      "undefined",
-			"Namespace": "undefined",
+			"Name":      chartRequested.Name(),
+			"Namespace": fmt.Sprintf("extension-%s", chartRequested.Name()),
 			"Revision":  1,
 			"Service":   "Helm",
 		},

--- a/pkg/extension/publish.go
+++ b/pkg/extension/publish.go
@@ -184,9 +184,9 @@ func Load(path string) (*api.Extension, error) {
 		return nil, err
 	}
 
-	if err = LoadApplicationClass(metadata.Name, tempDir); err != nil {
-		return nil, err
-	}
+	//if err = LoadApplicationClass(metadata.Name, tempDir); err != nil {
+	//	return nil, err
+	//}
 
 	ch, err := loader.LoadDir(tempDir)
 	if err != nil {

--- a/pkg/extension/templatessimple/charts/base/templates/iframe.yaml
+++ b/pkg/extension/templatessimple/charts/base/templates/iframe.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: [[ .Name ]]-cm-iframe
+  name: [[ .Name ]]-iframe
   namespace: extension-[[ .Name ]]
 data:
   index.js: |-

--- a/pkg/extension/templatessimple/charts/base/templates/jsbundle.yaml
+++ b/pkg/extension/templatessimple/charts/base/templates/jsbundle.yaml
@@ -6,7 +6,7 @@ spec:
   rawFrom:
     configMapKeyRef:
       key: index.js
-      name: [[ .Name ]]-cm-{{ .Values.extEmbed }}
+      name: [[ .Name ]]-{{ .Values.extEmbed }}
       namespace: extension-[[ .Name ]]
 status:
   link: /dist/[[ .Name ]]/index.js

--- a/pkg/extension/templatessimple/charts/base/templates/link.yaml
+++ b/pkg/extension/templatessimple/charts/base/templates/link.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: [[ .Name ]]-cm-link
+  name: [[ .Name ]]-link
   namespace: extension-[[ .Name ]]
 data:
   index.js: |-

--- a/pkg/extension/templatessimple/charts/base/values.yaml
+++ b/pkg/extension/templatessimple/charts/base/values.yaml
@@ -2,7 +2,7 @@
 extSvcName: demo
 extSvcPort: 80
 # Mount location e.g. topbar,global,toolbox,access,cluster,workspace,project,platformSettings
-extParent: topbar
+extParent: global
 # The hyperlink name of the dashboard
 extTitle: demo
 # Extension package description


### PR DESCRIPTION
### What this PR does / why we need it:

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
