### PR TITLE
Add support for symlink in package command

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -47,7 +47,7 @@ func (o *packageOptions) packageCmd(_ *cobra.Command, args []string) error {
 	}
 	defer os.RemoveAll(tempDir) // nolint
 
-	// Copy with FollowSymLink option to resolve symlinks
+	// Configure copy to follow symlinks and copy their target content
 	opt := copy.Options{
 		OnSymlink: func(_ string) copy.SymlinkAction {
 			return copy.Deep


### PR DESCRIPTION
### What this PR does / why we need it:

English:
This PR fixes the symlink handling issue in the package command. When packaging extensions that contain symbolic links in the charts directory, the original implementation would copy the symlinks themselves rather than their target contents. This caused Helm's loader.LoadDir() to fail when trying to resolve these symlinks in the temporary directory, as the original paths were no longer accessible.

The fix adds the OnSymlink option to the copy.Copy() function, configuring it to follow symlinks and copy the actual content (using copy.Deep). This ensures that all files are properly resolved and accessible when Helm loads the chart.

中文:
此 PR 修复了 package 命令中的软链接处理问题。当打包包含软链接的扩展（在 charts 目录中）时，原始实现会复制软链接本身而不是它们指向的目标内容。这导致 Helm 的 loader.LoadDir() 在尝试解析临时目录中的软链接时失败，因为原始路径已经不可访问。

修复方法是为 copy.Copy() 函数添加 OnSymlink 选项，配置其跟随软链接并复制实际内容（使用 copy.Deep）。这确保了 Helm 加载 chart 时所有文件都能被正确解析和访问。


### Does this PR introduced a user-facing change?

```release-note
Fixed: The package command now properly handles symbolic links in the charts directory, resolving them to their target content instead of copying the symlinks themselves.
修复：package 命令现在可以正确处理 charts 目录中的软链接，将其解析为目标内容而不是复制软链接本身。
```
