### PR TITLE
optimize the deletion order in the unpublish <extension> command.

### DIFF
--- a/cmd/unpublish.go
+++ b/cmd/unpublish.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	corev1alpha1 "kubesphere.io/api/core/v1alpha1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,6 +35,7 @@ func unpublishExtensionCmd() *cobra.Command {
 }
 
 func (o *unpublishOptions) unpublish(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
 	name := args[0]
 	fmt.Printf("unpublish extension %s\n", name)
 
@@ -45,11 +48,25 @@ func (o *unpublishOptions) unpublish(cmd *cobra.Command, args []string) error {
 	}
 
 	extensionVersions := &corev1alpha1.ExtensionVersionList{}
-	if err = genericClient.List(context.Background(), extensionVersions, runtimeclient.MatchingLabels{
+	if err = genericClient.List(ctx, extensionVersions, runtimeclient.MatchingLabels{
 		corev1alpha1.ExtensionReferenceLabel: name,
 	}); err != nil {
 		return err
 	}
+
+	installPlan := &corev1alpha1.InstallPlan{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubesphere.io/v1alpha1",
+			Kind:       "InstallPlan",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if err := deleteObjAndWait(ctx, genericClient, installPlan, time.Minute, 2*time.Second); err != nil {
+		return err
+	}
+
 	objs := make([]runtimeclient.Object, 0)
 	for i := range extensionVersions.Items {
 		version := &extensionVersions.Items[i]
@@ -65,15 +82,7 @@ func (o *unpublishOptions) unpublish(cmd *cobra.Command, args []string) error {
 		}, version)
 	}
 
-	return deleteObjs(genericClient, append(objs, &corev1alpha1.InstallPlan{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kubesphere.io/v1alpha1",
-			Kind:       "InstallPlan",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}, &corev1alpha1.Extension{
+	return deleteObjs(ctx, genericClient, append(objs, &corev1alpha1.Extension{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kubesphere.io/v1alpha1",
 			Kind:       "Extension",
@@ -84,12 +93,38 @@ func (o *unpublishOptions) unpublish(cmd *cobra.Command, args []string) error {
 	})...)
 }
 
-func deleteObjs(c runtimeclient.Client, objs ...runtimeclient.Object) error {
+func deleteObjs(ctx context.Context, c runtimeclient.Client, objs ...runtimeclient.Object) error {
 	for _, obj := range objs {
 		fmt.Printf("deleting %s %s\n", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
-		if err := c.Delete(context.Background(), obj); err != nil && !errors.IsNotFound(err) {
+		if err := c.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
 	return nil
+}
+
+func deleteObjAndWait(ctx context.Context, c runtimeclient.Client, obj runtimeclient.Object, timeout, interval time.Duration) error {
+	fmt.Printf("deleting %s %s\n", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+	if err := c.Delete(ctx, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	key := runtimeclient.ObjectKeyFromObject(obj)
+	current, ok := obj.DeepCopyObject().(runtimeclient.Object)
+	if !ok {
+		return fmt.Errorf("object %T does not implement client.Object", obj)
+	}
+
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		if err := c.Get(ctx, key, current); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
 }


### PR DESCRIPTION
### What this PR does / why we need it:

In versions below KSE v4.2.1, the controller queries the corresponding ExtensionVersion before deleting the InstallPlan. If the ExtensionVersion has already been deleted, the InstallPlan deletion will be blocked and cannot be cleaned up properly. Therefore, the deletion order needs to be optimized.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
optimize the deletion order in the unpublish <extension> command.
```
